### PR TITLE
release: v0.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/gutenberg-test-helper",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "gutenberg test utils",
   "author": {
     "name": "Technote",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.0",
-    "@types/lodash": "^4.14.155",
+    "@types/lodash": "^4.14.156",
     "@types/mousetrap": "^1.6.3",
     "@types/node": "^14.0.13",
     "@typescript-eslint/eslint-plugin": "^3.3.0",
@@ -67,7 +67,7 @@
     "eslint-plugin-react": "^7.20.0",
     "jest": "^26.0.1",
     "jest-circus": "^26.0.1",
-    "ts-jest": "^26.1.0",
+    "ts-jest": "^26.1.1",
     "typescript": "^3.9.5"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -640,9 +640,9 @@
   integrity sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==
 
 "@types/babel__core@^7.1.7":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.8.tgz#057f725aca3641f49fc11c7a87a9de5ec588a5d7"
-  integrity sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==
+  version "7.1.9"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
+  integrity sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -722,10 +722,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/lodash@^4.14.155":
-  version "4.14.155"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
-  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
+"@types/lodash@^4.14.156":
+  version "4.14.156"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.156.tgz#cbe30909c89a1feeb7c60803e785344ea0ec82d1"
+  integrity sha512-l2AgHXcKUwx2DsvP19wtRPqZ4NkONjmorOdq4sMcxIjqdIuuV/ULo2ftuv4NUpevwfW7Ju/UKLqo0ZXuEt/8lQ==
 
 "@types/mousetrap@^1.6.3":
   version "1.6.3"
@@ -5071,9 +5071,9 @@ reakit-warning@^0.4.0:
     reakit-utils "^0.13.0"
 
 reakit@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.1.0.tgz#c30289907722a1fb1aa6a8c4990dac739c60e9c7"
-  integrity sha512-d/ERtwgBndBPsyPBPUl5jueyfFgsglIfQCnLMKuxM0PaWiIZ6Ys3XsYaNy/AaG8k46Ee5cQPMdRrR30nVcSToQ==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.1.1.tgz#77e09a242903735820d6020c4d41f5e99b350bdb"
+  integrity sha512-Ha/+TYBjJYDE1qQIhQX0CmVHMQuaK4qFasjHQgqIHLsvz4cHD8vCgRqwXWKSbBTH8hYpgvy057vVeyoQh6k/tQ==
   dependencies:
     "@popperjs/core" "^2.4.2"
     body-scroll-lock "^3.0.2"
@@ -5846,10 +5846,10 @@ traverse@^0.6.6:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
-ts-jest@^26.1.0:
-  version "26.1.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.1.0.tgz#e9070fc97b3ea5557a48b67c631c74eb35e15417"
-  integrity sha512-JbhQdyDMYN5nfKXaAwCIyaWLGwevcT2/dbqRPsQeh6NZPUuXjZQZEfeLb75tz0ubCIgEELNm6xAzTe5NXs5Y4Q==
+ts-jest@^26.1.1:
+  version "26.1.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.1.1.tgz#b98569b8a4d4025d966b3d40c81986dd1c510f8d"
+  integrity sha512-Lk/357quLg5jJFyBQLnSbhycnB3FPe+e9i7ahxokyXxAYoB0q1pPmqxxRPYr4smJic1Rjcf7MXDBhZWgxlli0A==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (55decd3143e2aca690a2268fbc40a58515c8af72)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/gutenberg-test-helper/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>ncu -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/gutenberg-test-helper/gutenberg-test-helper/package.json

 @types/lodash  ^4.14.155  →  ^4.14.156 
 ts-jest          ^26.1.0  →    ^26.1.1 

Run npm install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 25.69s.
```

### stderr:

```Shell
warning "@wordpress/api-fetch > @wordpress/url > react-native-url-polyfill@1.1.2" has unmet peer dependency "react-native@*".
warning "@wordpress/block-editor > @wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/block-editor > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
```

</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 490 new dependencies.
info Direct dependencies
├─ @types/jest@26.0.0
├─ @types/lodash@4.14.156
├─ @types/mousetrap@1.6.3
├─ @typescript-eslint/eslint-plugin@3.3.0
├─ @typescript-eslint/parser@3.3.0
├─ @wordpress/format-library@1.20.0
├─ enzyme-adapter-react-16@1.15.2
├─ enzyme-to-json@3.5.0
├─ enzyme@3.11.0
├─ eslint-plugin-react@7.20.0
├─ eslint@7.3.0
├─ jest-circus@26.0.1
├─ jest@26.0.1
├─ react-autosize-textarea@7.0.0
├─ react-dom@16.13.1
├─ react@16.13.1
├─ ts-jest@26.1.1
└─ typescript@3.9.5
info All dependencies
├─ @babel/core@7.10.3
├─ @babel/helper-function-name@7.10.3
├─ @babel/helper-get-function-arity@7.10.3
├─ @babel/helper-member-expression-to-functions@7.10.3
├─ @babel/helper-module-imports@7.10.3
├─ @babel/helper-module-transforms@7.10.1
├─ @babel/helper-optimise-call-expression@7.10.3
├─ @babel/helper-replace-supers@7.10.1
├─ @babel/helper-simple-access@7.10.1
├─ @babel/helpers@7.10.1
├─ @babel/highlight@7.10.3
├─ @babel/plugin-syntax-async-generators@7.8.4
├─ @babel/plugin-syntax-bigint@7.8.3
├─ @babel/plugin-syntax-class-properties@7.10.1
├─ @babel/plugin-syntax-import-meta@7.10.1
├─ @babel/plugin-syntax-json-strings@7.8.3
├─ @babel/plugin-syntax-logical-assignment-operators@7.10.1
├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
├─ @babel/plugin-syntax-numeric-separator@7.10.1
├─ @babel/plugin-syntax-object-rest-spread@7.8.3
├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
├─ @babel/plugin-syntax-optional-chaining@7.8.3
├─ @babel/runtime-corejs3@7.10.3
├─ @babel/template@7.10.3
├─ @bcoe/v8-coverage@0.2.3
├─ @cnakazawa/watch@1.0.4
├─ @emotion/cache@10.0.29
├─ @emotion/core@10.0.28
├─ @emotion/css@10.0.27
├─ @emotion/is-prop-valid@0.8.8
├─ @emotion/native@10.0.27
├─ @emotion/primitives-core@10.0.27
├─ @emotion/styled-base@10.0.31
├─ @emotion/styled@10.0.27
├─ @emotion/stylis@0.8.5
├─ @emotion/unitless@0.7.5
├─ @emotion/weak-memoize@0.2.5
├─ @istanbuljs/load-nyc-config@1.1.0
├─ @jest/globals@26.0.1
├─ @jest/reporters@26.0.1
├─ @jest/test-sequencer@26.0.1
├─ @popperjs/core@2.4.2
├─ @sinonjs/commons@1.8.0
├─ @sinonjs/fake-timers@6.0.1
├─ @tannin/compile@1.1.0
├─ @tannin/evaluate@1.2.0
├─ @tannin/plural-forms@1.1.0
├─ @tannin/postfix@1.1.0
├─ @types/babel__core@7.1.9
├─ @types/babel__generator@7.6.1
├─ @types/babel__template@7.0.2
├─ @types/babel__traverse@7.0.12
├─ @types/color-name@1.1.1
├─ @types/eslint-visitor-keys@1.0.0
├─ @types/graceful-fs@4.1.3
├─ @types/istanbul-lib-coverage@2.0.3
├─ @types/istanbul-lib-report@3.0.0
├─ @types/jest@26.0.0
├─ @types/json-schema@7.0.5
├─ @types/lodash@4.14.156
├─ @types/mousetrap@1.6.3
├─ @types/normalize-package-data@2.4.0
├─ @types/parse-json@4.0.0
├─ @types/prettier@2.0.1
├─ @types/stack-utils@1.0.1
├─ @types/yargs-parser@15.0.0
├─ @typescript-eslint/eslint-plugin@3.3.0
├─ @typescript-eslint/parser@3.3.0
├─ @wordpress/block-directory@1.11.0
├─ @wordpress/block-serialization-default-parser@3.6.0
├─ @wordpress/edit-post@3.19.0
├─ @wordpress/format-library@1.20.0
├─ @wordpress/interface@0.5.0
├─ @wordpress/redux-routine@3.9.0
├─ @wordpress/token-list@1.10.0
├─ @wordpress/warning@1.1.0
├─ acorn-globals@6.0.0
├─ acorn-jsx@5.2.0
├─ acorn-walk@7.2.0
├─ acorn@7.3.1
├─ ajv@6.12.2
├─ ansi-colors@3.2.4
├─ anymatch@3.1.1
├─ argparse@1.0.10
├─ arr-flatten@1.1.0
├─ array-filter@1.0.0
├─ array.prototype.find@2.1.1
├─ array.prototype.flat@1.2.3
├─ asap@2.0.6
├─ asn1@0.2.4
├─ assign-symbols@1.0.0
├─ astral-regex@1.0.0
├─ asynckit@0.4.0
├─ atob@2.1.2
├─ autosize@4.0.2
├─ aws-sign2@0.7.0
├─ aws4@1.10.0
├─ babel-jest@26.0.1
├─ babel-plugin-jest-hoist@26.0.0
├─ babel-plugin-macros@2.8.0
├─ babel-plugin-syntax-jsx@6.18.0
├─ babel-preset-current-node-syntax@0.1.3
├─ babel-preset-jest@26.0.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ base64-js@1.3.1
├─ bcrypt-pbkdf@1.0.2
├─ body-scroll-lock@3.0.3
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ brcast@2.0.2
├─ browser-process-hrtime@1.0.0
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ buffer-from@1.1.1
├─ buffer@5.6.0
├─ cache-base@1.0.1
├─ camelcase@5.3.1
├─ camelize@1.0.0
├─ capture-exit@2.0.0
├─ caseless@0.12.0
├─ char-regex@1.0.2
├─ cheerio@1.0.0-rc.3
├─ ci-info@2.0.0
├─ class-utils@0.3.6
├─ clipboard@2.0.6
├─ cliui@6.0.0
├─ collection-visit@1.0.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ combined-stream@1.0.8
├─ commander@2.20.3
├─ compute-scroll-into-view@1.0.14
├─ computed-style@0.1.4
├─ concat-map@0.0.1
├─ convert-source-map@1.7.0
├─ copy-descriptor@0.1.1
├─ core-js-pure@3.6.5
├─ core-js@1.2.7
├─ core-util-is@1.0.2
├─ cosmiconfig@6.0.0
├─ cross-spawn@7.0.3
├─ css-color-keywords@1.0.0
├─ css-mediaquery@0.1.2
├─ css-select@1.2.0
├─ css-to-react-native@2.3.2
├─ css-what@2.1.3
├─ cssom@0.4.4
├─ cssstyle@2.3.0
├─ csstype@2.6.10
├─ dashdash@1.14.1
├─ data-urls@2.0.0
├─ decimal.js@10.2.0
├─ decode-uri-component@0.2.0
├─ dedent@0.7.0
├─ deep-is@0.1.3
├─ deepmerge@4.2.2
├─ delayed-stream@1.0.0
├─ delegate@3.2.0
├─ detect-newline@3.1.0
├─ diff-sequences@26.0.0
├─ diff@4.0.2
├─ direction@1.0.4
├─ discontinuous-range@1.0.0
├─ doctrine@2.1.0
├─ document.contains@1.0.2
├─ domexception@2.0.1
├─ domhandler@2.4.2
├─ domutils@1.5.1
├─ downshift@4.1.0
├─ ecc-jsbn@0.1.2
├─ emoji-regex@7.0.3
├─ encoding@0.1.12
├─ end-of-stream@1.4.4
├─ enquirer@2.3.5
├─ enzyme-adapter-react-16@1.15.2
├─ enzyme-adapter-utils@1.13.0
├─ enzyme-to-json@3.5.0
├─ enzyme@3.11.0
├─ error-ex@1.3.2
├─ es-to-primitive@1.2.1
├─ escodegen@1.14.2
├─ eslint-plugin-react@7.20.0
├─ eslint-scope@5.1.0
├─ eslint@7.3.0
├─ espree@7.1.0
├─ esprima@4.0.1
├─ esquery@1.3.1
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ execa@4.0.2
├─ expand-brackets@2.1.4
├─ extend@3.0.2
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fast-average-color@4.3.0
├─ fast-deep-equal@3.1.3
├─ fast-levenshtein@2.0.6
├─ fast-memoize@2.5.2
├─ fbjs@0.8.17
├─ file-entry-cache@5.0.1
├─ fill-range@7.0.1
├─ find-root@1.1.0
├─ flat-cache@2.0.1
├─ flatted@2.0.2
├─ for-in@1.0.2
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ fs.realpath@1.0.0
├─ functions-have-names@1.2.1
├─ gensync@1.0.0-beta.1
├─ get-package-type@0.1.0
├─ get-stream@5.1.0
├─ get-value@2.0.6
├─ getpass@0.1.7
├─ gettext-parser@1.4.0
├─ glob-parent@5.1.1
├─ glob@7.1.6
├─ global-cache@1.2.1
├─ globals@12.4.0
├─ good-listener@1.2.2
├─ gradient-parser@0.1.5
├─ growly@1.3.0
├─ har-schema@2.0.0
├─ har-validator@5.1.3
├─ has-value@1.0.0
├─ hoist-non-react-statics@3.3.2
├─ hosted-git-info@2.8.8
├─ hpq@1.3.0
├─ html-element-map@1.2.0
├─ html-encoding-sniffer@2.0.1
├─ html-escaper@2.0.2
├─ htmlparser2@3.10.1
├─ http-signature@1.2.0
├─ human-signals@1.1.1
├─ iconv-lite@0.4.24
├─ ieee754@1.1.13
├─ ignore@4.0.6
├─ import-fresh@3.2.1
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ internal-slot@1.0.2
├─ ip-regex@2.1.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-boolean-object@1.0.1
├─ is-callable@1.2.0
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.2
├─ is-descriptor@1.0.2
├─ is-docker@2.0.0
├─ is-extglob@2.1.1
├─ is-number-object@1.0.4
├─ is-plain-object@2.0.4
├─ is-potential-custom-element-name@1.0.0
├─ is-regex@1.1.0
├─ is-stream@1.1.0
├─ is-subset@0.1.1
├─ is-symbol@1.0.3
├─ is-touch-device@1.0.1
├─ is-windows@1.0.2
├─ is-wsl@2.2.0
├─ isarray@1.0.0
├─ isomorphic-fetch@2.2.1
├─ isstream@0.1.2
├─ istanbul-lib-source-maps@4.0.0
├─ istanbul-reports@3.0.2
├─ jest-changed-files@26.0.1
├─ jest-circus@26.0.1
├─ jest-cli@26.0.1
├─ jest-docblock@26.0.0
├─ jest-environment-jsdom@26.0.1
├─ jest-environment-node@26.0.1
├─ jest-leak-detector@26.0.1
├─ jest-pnp-resolver@1.2.1
├─ jest-resolve-dependencies@26.0.1
├─ jest-serializer@26.0.0
├─ jest-watcher@26.0.1
├─ jest@26.0.1
├─ js-tokens@4.0.0
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.1.3
├─ jsprim@1.4.1
├─ jsx-ast-utils@2.4.1
├─ kind-of@3.2.2
├─ kleur@3.0.3
├─ leven@3.1.0
├─ lines-and-columns@1.1.6
├─ locate-path@5.0.0
├─ lodash.escape@4.0.1
├─ lodash.flattendeep@4.4.0
├─ lodash.isequal@4.5.0
├─ lodash.memoize@4.1.2
├─ lodash.sortby@4.7.0
├─ loose-envify@1.4.0
├─ make-error@1.3.6
├─ makeerror@1.0.11
├─ map-visit@1.0.0
├─ micromatch@4.0.2
├─ mime-db@1.44.0
├─ mime-types@2.1.27
├─ mimic-fn@2.1.0
├─ minimist@1.2.5
├─ mixin-deep@1.3.2
├─ mkdirp@1.0.4
├─ moment-timezone@0.5.31
├─ moment@2.27.0
├─ moo@0.5.1
├─ ms@2.1.2
├─ nanomatch@1.2.13
├─ nearley@2.19.4
├─ nice-try@1.0.5
├─ node-fetch@1.7.3
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-notifier@7.0.1
├─ normalize-package-data@2.5.0
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ nth-check@1.0.2
├─ nwsapi@2.2.0
├─ oauth-sign@0.9.0
├─ object-copy@0.1.0
├─ object-keys@1.1.1
├─ once@1.4.0
├─ onetime@5.1.0
├─ optionator@0.9.1
├─ p-each-series@2.1.0
├─ p-finally@1.0.0
├─ p-limit@2.3.0
├─ p-locate@4.1.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse5@5.1.1
├─ pascalcase@0.1.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@4.0.0
├─ picomatch@2.2.2
├─ pirates@4.0.1
├─ pkg-dir@4.2.0
├─ posix-character-classes@0.1.1
├─ postcss-value-parser@3.3.1
├─ progress@2.0.3
├─ promise@7.3.1
├─ prompts@2.3.2
├─ prop-types-exact@1.2.0
├─ punycode@2.1.1
├─ qs@6.9.4
├─ raf@3.4.1
├─ railroad-diagrams@1.0.0
├─ randexp@0.4.6
├─ re-resizable@6.5.0
├─ react-addons-shallow-compare@15.6.2
├─ react-autosize-textarea@7.0.0
├─ react-dates@17.2.0
├─ react-dom@16.13.1
├─ react-easy-crop@3.0.1
├─ react-moment-proptypes@1.7.0
├─ react-native-url-polyfill@1.1.2
├─ react-outside-click-handler@1.3.0
├─ react-portal@4.2.1
├─ react-resize-aware@3.0.1
├─ react-spring@8.0.27
├─ react-test-renderer@16.13.1
├─ react-use-gesture@7.0.15
├─ react-with-direction@1.3.1
├─ react-with-styles-interface-css@4.0.3
├─ react-with-styles@3.2.3
├─ react@16.13.1
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ reakit-system@0.13.0
├─ reakit-warning@0.4.0
├─ reakit@1.1.1
├─ redux-multi@0.1.12
├─ redux-optimist@1.0.0
├─ redux@4.0.5
├─ reflect.ownkeys@0.2.0
├─ regexp.prototype.flags@1.3.0
├─ regexpp@3.1.0
├─ remove-trailing-separator@1.1.0
├─ repeat-element@1.1.3
├─ request-promise-core@1.1.3
├─ request-promise-native@1.0.8
├─ request@2.88.2
├─ resolve-cwd@3.0.0
├─ resolve-url@0.2.1
├─ resolve@1.17.0
├─ rimraf@3.0.2
├─ rst-selector-parser@2.2.3
├─ rsvp@4.8.5
├─ rungen@0.3.2
├─ safe-buffer@5.2.1
├─ safer-buffer@2.1.2
├─ sane@4.1.0
├─ saxes@5.0.1
├─ select@1.1.2
├─ semver@5.7.1
├─ set-value@2.0.1
├─ setimmediate@1.0.5
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ shellwords@0.1.1
├─ showdown@1.9.1
├─ signal-exit@3.0.3
├─ simple-html-tokenizer@0.5.9
├─ sisteransi@1.0.5
├─ slice-ansi@2.1.0
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.3
├─ source-map-support@0.5.19
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ split-string@3.1.0
├─ sprintf-js@1.1.2
├─ sshpk@1.16.1
├─ static-extend@0.1.2
├─ stealthy-require@1.1.1
├─ string_decoder@1.3.0
├─ string.prototype.matchall@4.0.2
├─ string.prototype.trim@1.2.1
├─ string.prototype.trimend@1.0.1
├─ string.prototype.trimstart@1.0.1
├─ strip-bom@4.0.0
├─ strip-eof@1.0.0
├─ strip-final-newline@2.0.0
├─ strip-json-comments@3.1.0
├─ supports-hyperlinks@2.1.0
├─ symbol-observable@1.2.0
├─ symbol-tree@3.2.4
├─ table@5.4.6
├─ tannin@1.2.0
├─ terminal-link@2.1.1
├─ test-exclude@6.0.0
├─ text-table@0.2.0
├─ tiny-emitter@2.1.0
├─ tmpl@1.0.4
├─ to-fast-properties@2.0.0
├─ to-object-path@0.3.0
├─ to-regex-range@5.0.1
├─ tough-cookie@2.5.0
├─ tr46@2.0.2
├─ traverse@0.6.6
├─ ts-jest@26.1.1
├─ tslib@1.11.2
├─ tunnel-agent@0.6.0
├─ turbo-combine-reducers@1.0.2
├─ tweetnacl@0.14.5
├─ type-detect@4.0.8
├─ typedarray-to-buffer@3.1.5
├─ typescript@3.9.5
├─ ua-parser-js@0.7.21
├─ union-value@1.0.1
├─ unset-value@1.0.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ use-memo-one@1.1.1
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ uuid@7.0.3
├─ v8-compile-cache@2.1.1
├─ v8-to-istanbul@4.1.4
├─ validate-npm-package-license@3.0.4
├─ verror@1.10.0
├─ w3c-hr-time@1.0.2
├─ w3c-xmlserializer@2.0.0
├─ walker@1.0.7
├─ whatwg-fetch@3.0.0
├─ whatwg-url-without-unicode@8.0.0-1
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ wrap-ansi@6.2.0
├─ write-file-atomic@3.0.3
├─ write@1.0.3
├─ ws@7.3.0
├─ xmlchars@2.2.0
├─ xregexp@4.3.0
├─ yaml@1.10.0
└─ yargs-parser@18.1.3
Done in 11.25s.
```

### stderr:

```Shell
warning @wordpress/block-editor > @wordpress/components > react-dates > react-addons-shallow-compare > fbjs > core-js@1.2.7: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning jsdom > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning jest > @jest/core > jest-haste-map > sane > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
warning jest > @jest/core > jest-haste-map > sane > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning "@wordpress/api-fetch > @wordpress/url > react-native-url-polyfill@1.1.2" has unmet peer dependency "react-native@*".
warning "@wordpress/block-editor > @wordpress/components > @emotion/native@10.0.27" has unmet peer dependency "react-native@>=0.14.0 <1".
warning "@wordpress/block-editor > @wordpress/components > react-dates > react-with-styles@3.2.3" has unmet peer dependency "react-with-direction@^1.1.0".
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.4
0 vulnerabilities found - Packages audited: 874
Done in 0.94s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)